### PR TITLE
Properly implement cooldown step parsing and explicitly support WSD schedules

### DIFF
--- a/src/contrastors/config.py
+++ b/src/contrastors/config.py
@@ -13,6 +13,7 @@ class TrainArgs(BaseModel):
     warmup_steps: Optional[int] = None
     warmup_pct: Optional[float] = None
     cooldown_steps: Optional[int] = None
+    cooldown_pct: Optional[float] = None
     checkpoint: Optional[str] = None
     wandb: bool
     wandb_project_name: str


### PR DESCRIPTION
Previously, cooldown steps were _defined_ in the config, but never used anywhere -- this PR fixes that, and brings it up to par with the warmup hyperparams.  
Also, inspired by ModernBERT, it adds explicit support for WSD by manually constructing the scheduler kwargs to pass the stable and decay steps